### PR TITLE
Add action info to UI

### DIFF
--- a/slate/slate/slate.py
+++ b/slate/slate/slate.py
@@ -63,6 +63,8 @@ class SlateClient:
         obs, _ = self.env.reset()
         self.current_frame = None
         self.q_values = []
+        self.action_str = "None"
+        self.action_meanings = env.unwrapped.get_action_meanings()
         self.reward = 0
         self.done = False
         self.info = {}
@@ -179,6 +181,7 @@ class SlateClient:
                 "done": done,
                 "info": info,
                 "q_values": q_values,
+                "action": self.action_str,
                 "timestamp": datetime.now().isoformat()
             }
         }
@@ -211,6 +214,8 @@ class SlateClient:
         action = self.agent.get_action(self.frame_buffer.state())
         obs, reward, done, truncated, info = self.env.step(action)
         self.frame_buffer.append(obs)
+
+        self.action_str = self.action_meanings[action]
 
         with self.state_lock:
             self.current_frame = self.encode_frame(frame)
@@ -247,6 +252,7 @@ class SlateClient:
                     "done": self.done,
                     "info": self.info,
                     "q_values": self.q_values,
+                    "action": self.action_str,
                     "high_score": self.high_score,
                     "checkpoint": self.checkpoint
                 }

--- a/slate/slate/static/script.js
+++ b/slate/slate/static/script.js
@@ -276,6 +276,7 @@ class SlateViewer {
     const metadata = this.currentPlaybackData.metadata[this.playbackIndex];
     this.updateInfoDisplay({
       q_values: metadata.q_values,
+      action: metadata.action,
       reward: metadata.reward,
       checkpoint: this.currentPlaybackData.checkpoint
     });
@@ -321,7 +322,7 @@ class SlateViewer {
     const qvals = payload.q_values.map((v) => Number(v).toFixed(2));
     document.getElementById("info").innerHTML = `
       <div>Q-values: [${qvals.join(", ")}]</div>
-      <div>Action: [auto]</div>
+      <div>Action: ${payload.action}</div>
       <div>Reward: +${payload.reward}</div>
       <div>Checkpoint: ${payload.checkpoint}</div>
     `;


### PR DESCRIPTION
Takes the action info, converts it to a string (name of the action) and puts that action name into the UI along with the other state information.